### PR TITLE
Update manifest.toml spip 4.3.3

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -54,7 +54,7 @@ ram.runtime = "50M"
 
 [resources]
         [resources.sources.main]
-        url = "https://files.spip.net/spip/archives/spip-v4.2.6.zip"
+        url = "https://files.spip.net/spip/archives/spip-v4.3.3.zip"
         sha256 = "fae86da7472e187335c0923c1f8263b04da4b5cad374e7c94b1f62e5e8e99b18"
         in_subdir = false
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "SPIP"
 description.en = "CMS with a focus on collaborative edition and multilingualism"
 description.fr = "CMS conçu pour l'édition collaborative et le multilinguisme"
 
-version = "4.2.6~ynh2"
+version = "4.3.3~ynh1"
 
 maintainers = ["cyp"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -55,7 +55,7 @@ ram.runtime = "50M"
 [resources]
         [resources.sources.main]
         url = "https://files.spip.net/spip/archives/spip-v4.3.3.zip"
-        sha256 = "fae86da7472e187335c0923c1f8263b04da4b5cad374e7c94b1f62e5e8e99b18"
+        sha256 = "e2a7e6094a398843b83d22f6ab4ed2433ceea8278ef183da0e324c31ef95ac60"
         in_subdir = false
 
 


### PR DESCRIPTION
paquet plus maintenu, naïvement ça « juste marche »

## Problem

- no usage possible with so old version 

## Solution

- use last archive

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
