### PR TITLE
[fix] Remove X-Robots-Tag: none and other redundant security header

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -19,12 +19,6 @@ location __PATH__/ {
 
   # Add headers to serve security related headers
   more_set_headers 'Strict-Transport-Security: max-age=15768000';
-  more_set_headers 'X-Content-Type-Options: nosniff';
-  more_set_headers 'X-Frame-Options: SAMEORIGIN';
-  more_set_headers 'X-XSS-Protection: 1, mode=block';
-  more_set_headers 'X-Robots-Tag: none';
-  more_set_headers 'X-Download-Options: noopen';
-  more_set_headers 'X-Permitted-Cross-Domain-Policies: none';
 
   location ~^/(tmp|config|\.ht)/{
     deny all;


### PR DESCRIPTION
## Problem

https://github.com/YunoHost-Apps/spip_ynh/issues/87

I also discover a security rewrite headers of the one defined in https://github.com/YunoHost/yunohost/blob/dev/conf/nginx/security.conf.inc

## Solution

- Remove those headers

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
