### PR TITLE
v4.4.7 Update version and source URL for SPIP

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "SPIP"
 description.en = "CMS with a focus on collaborative edition and multilingualism"
 description.fr = "CMS conçu pour l'édition collaborative et le multilinguisme"
 
-version = "4.4.6~ynh1"
+version = "4.4.7~ynh1"
 
 maintainers = ["cyp"]
 
@@ -55,8 +55,8 @@ ram.runtime = "50M"
 
 [resources]
         [resources.sources.main]
-        url = "https://files.spip.net/spip/archives/spip-v4.4.6.zip"
-        sha256 = "dd95c3356733154ebe1624e5894d5220ddf80ced61c5cd873d838413526b797c"
+        url = "https://files.spip.net/spip/archives/spip-v4.4.7.zip"
+        sha256 = "1886e253b1cdcb7e2622e8f58bc81574cd8bc238bd75be9587263a10eb384a24"
         in_subdir = false
 
 


### PR DESCRIPTION
## Problem

- *New release v4.4.7 is out*
https://blog.spip.net/Mise-a-jour-de-maintenance-sortie-de-SPIP-4-4-7.html

## Solution

- *Update to v4.4.7*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
