### PR TITLE
Bump version to 4.4.8 and update source URL

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "SPIP"
 description.en = "CMS with a focus on collaborative edition and multilingualism"
 description.fr = "CMS conçu pour l'édition collaborative et le multilinguisme"
 
-version = "4.4.7~ynh1"
+version = "4.4.8~ynh1"
 
 maintainers = ["cyp"]
 
@@ -55,8 +55,8 @@ ram.runtime = "50M"
 
 [resources]
         [resources.sources.main]
-        url = "https://files.spip.net/spip/archives/spip-v4.4.7.zip"
-        sha256 = "1886e253b1cdcb7e2622e8f58bc81574cd8bc238bd75be9587263a10eb384a24"
+        url = "https://files.spip.net/spip/archives/spip-v4.4.8.zip"
+        sha256 = "881944c89e354633604c2b324f55e550f50284e0dca50bd47a358bf9a2a67d7a"
         in_subdir = false
 
 


### PR DESCRIPTION
## Problem

- *Security update - This version fixes two minor XSS vulnerabilities.*
https://blog.spip.net/Mise-a-jour-de-securite-sortie-de-SPIP-4-4-8.html

## Solution

- *Update to v4.4.8*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
