### PR TITLE
Add test upgrade

### DIFF
--- a/tests.toml
+++ b/tests.toml
@@ -6,10 +6,10 @@ test_format = 1.0
     # Default args to use for install
     # -------------------------------
 
-args.users_status = "Editor"
+    args.users_status = "Editor"
 
     # -------------------------------
     # Commits to test upgrade from
     # -------------------------------
 
-test_upgrade_from.cbf29f0cb6aba6fced7d9774de6944de4cc2e8d4.name = "Upgrade from 4.3.6~ynh1"
+    test_upgrade_from.cbf29f0cb6aba6fced7d9774de6944de4cc2e8d4.name = "Upgrade from 4.3.6~ynh1"

--- a/tests.toml
+++ b/tests.toml
@@ -6,4 +6,10 @@ test_format = 1.0
     # Default args to use for install
     # -------------------------------
 
-	args.users_status = "Editor"
+args.users_status = "Editor"
+
+    # -------------------------------
+    # Commits to test upgrade from
+    # -------------------------------
+
+test_upgrade_from.cbf29f0cb6aba6fced7d9774de6944de4cc2e8d4.name = "Upgrade from 4.3.6~ynh1"


### PR DESCRIPTION
## Problem

- *Test upgrade from an old or not maintained version*
https://www.spip.net/en_article6499.html

## Solution

- *Add a line in tests.toml in order to test upgrade from v4.3.6 *
This could be useful in mid-2026 when upgrading from v4.4.x to v5.x.x.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
