### PR TITLE
V4.4.19

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -4,7 +4,7 @@ id = "spip"
 name = "SPIP"
 description.en = "CMS with a focus on collaborative edition and multilingualism"
 description.fr = "CMS conçu pour l'édition collaborative et le multilinguisme"
-version = "4.4.16~ynh1"
+version = "4.4.19~ynh1"
 
 maintainers = ["genma"]
 
@@ -54,8 +54,8 @@ ram.runtime = "50M"
 
 [resources]
         [resources.sources.main]
-        url = "https://files.spip.net/spip/archives/spip-v4.4.16.zip"
-        sha256 = "20d3495102b0ae9d278ebaadda30156a4f2fd45d65d6470cad1ee07da7c6487c"
+        url = "https://files.spip.net/spip/archives/spip-v4.4.19.zip"
+        sha256 = "20bd1a33954b9886e72cb3e9f1648eb8811a82c39caee26cc627b20a512ed547"
         in_subdir = false
     
     [resources.system_user]


### PR DESCRIPTION
Updated version and source URL for SPIP.

## Problem

- *Version 4.4.19 fixes a few bugs introduced by version 4.4.18, including one that broke the password recovery process.*
https://blog.spip.net/Mise-a-jour-corrective-sortie-de-SPIP-4-4-19.html

## Solution

- *Update to v4.4.19*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
