### PR TITLE
Update v4.4.21

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -4,7 +4,7 @@ id = "spip"
 name = "SPIP"
 description.en = "CMS with a focus on collaborative edition and multilingualism"
 description.fr = "CMS conçu pour l'édition collaborative et le multilinguisme"
-version = "4.4.20~ynh1"
+version = "4.4.21~ynh1"
 
 maintainers = ["genma"]
 
@@ -56,8 +56,8 @@ ram.runtime = "50M"
 
 [resources]
         [resources.sources.main]
-        url = "https://files.spip.net/spip/archives/spip-v4.4.20.zip"
-        sha256 = "4fea8035a25ed5e254210a0e2819739fe5f539d0869511792d0509a2c0ef03e6"
+        url = "https://files.spip.net/spip/archives/spip-v4.4.21.zip"
+        sha256 = "0a8f770923c38e72d95c3db62673a946f090a557dbece5b5bbb6a1baa214cd21"
         in_subdir = false
     
     [resources.system_user]


### PR DESCRIPTION
## Problem

- *This release fixes a universal (unconditional) pre-authentication RCE vulnerability affecting version 4.4.20 of SPIP.*
https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-4-21.html

## Solution

- *Update to v4.4.21*

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)


